### PR TITLE
Use correct 'ask' function

### DIFF
--- a/request-logger-with-async-std/src/main.rs
+++ b/request-logger-with-async-std/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
                     round_robin %= workers.elems().len();
 
                     // Distribute tcp streams
-                    workers.elems()[round_robin].ask(stream.unwrap()).unwrap();
+                    workers.elems()[round_robin].ask_anonymously(stream.unwrap()).unwrap();
                 }
 
                 // Unreachable, but showing the logic explicitly is nice.
@@ -86,7 +86,7 @@ fn get_workers() -> ChildrenRef {
                                     .unwrap();
                                 file.write_all(&data_buf).await.unwrap();
 
-                                stream.write("OK".as_bytes()).unwrap();
+                                stream.write_all(b"OK").unwrap();
                             };
                             _: _ => ();
                         }


### PR DESCRIPTION
The master branch fails to compile with:
```
/bastion-showcase/request-logger-with-async-std (master)
-$ cargo build
   Compiling request-logger-with-async-std v0.1.0 (/home/vladan/dev/git.social/bastion-showcase/request-logger-with-async-std)
error[E0599]: no method named `ask` found for struct `bastion::child_ref::ChildRef` in the current scope
  --> src/main.rs:47:50
   |
47 |                     workers.elems()[round_robin].ask(stream.unwrap()).unwrap();
   |                                                  ^^^ method not found in `bastion::child_ref::ChildRef`

error: aborting due to previous error
```

This patch also fixes a clippy warning for byte string annotation.